### PR TITLE
Fix failure on checkbox-starting body

### DIFF
--- a/app/webhooks.go
+++ b/app/webhooks.go
@@ -32,7 +32,7 @@ func (app *App) HandlePullRequest(payload PullRequestPayload) error {
 	context := "wiplock"
 	var state string
 	containsWIP := regexp.MustCompile("(?i)wip").MatchString(title)
-	containsUnchecked := regexp.MustCompile("\\n\\-\\s+\\[\\s+\\]([^\\n]+)").MatchString(body)
+	containsUnchecked := regexp.MustCompile("^\\-\\s+\\[\\s+\\]([^\\n]+)").MatchString(body)
 	if containsWIP || containsUnchecked {
 		state = "pending"
 	} else {


### PR DESCRIPTION
When the body starts with a checkbox like below, Wiplock can't recognize it, so it works like it's checked.

```
- [ ] 1st (no lines before here)
- [ ] 2nd
```